### PR TITLE
스프링 초기 로딩 시에 캐싱 위한 함수 호출

### DIFF
--- a/src/main/java/com/yapp/batch/BatchApplication.java
+++ b/src/main/java/com/yapp/batch/BatchApplication.java
@@ -1,0 +1,32 @@
+package com.yapp.batch;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@SpringBootApplication
+@EnableAsync
+@EnableScheduling
+public class BatchApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(BatchApplication.class, args);
+	}
+
+	@Bean
+	public Executor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(200); //8
+		executor.setMaxPoolSize(200); // 8
+		executor.setQueueCapacity(60000); // 5000
+		executor.setThreadNamePrefix("GithubLookup-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/java/com/yapp/fmz/FmzApplication.java
+++ b/src/main/java/com/yapp/fmz/FmzApplication.java
@@ -8,6 +8,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import javax.annotation.PostConstruct;
 import java.util.concurrent.Executor;
 
 @SpringBootApplication
@@ -30,5 +31,6 @@ public class FmzApplication {
 		executor.initialize();
 		return executor;
 	}
+
 
 }

--- a/src/main/java/com/yapp/fmz/controller/RoomController.java
+++ b/src/main/java/com/yapp/fmz/controller/RoomController.java
@@ -10,10 +10,8 @@ import com.yapp.fmz.service.RoomService;
 import com.yapp.fmz.service.ZoneService;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -97,5 +95,4 @@ public class RoomController {
 
         return "완료";
     }
-
 }

--- a/src/main/java/com/yapp/fmz/controller/RoomController.java
+++ b/src/main/java/com/yapp/fmz/controller/RoomController.java
@@ -1,10 +1,7 @@
 package com.yapp.fmz.controller;
 
 import com.yapp.fmz.domain.Room;
-import com.yapp.fmz.domain.Zone;
 import com.yapp.fmz.domain.dto.RoomDetailDto;
-import com.yapp.fmz.domain.dto.RoomDto;
-import com.yapp.fmz.domain.dto.ZoneDto;
 import com.yapp.fmz.repository.RoomRepository;
 import com.yapp.fmz.service.RoomService;
 import com.yapp.fmz.service.ZoneService;
@@ -14,10 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toList;
 
 
 @RestController

--- a/src/main/java/com/yapp/fmz/controller/ZoneController.java
+++ b/src/main/java/com/yapp/fmz/controller/ZoneController.java
@@ -1,6 +1,5 @@
 package com.yapp.fmz.controller;
 
-import ch.qos.logback.core.encoder.EchoEncoder;
 import com.yapp.fmz.domain.Zone;
 import com.yapp.fmz.domain.dto.RequestFindZoneDto;
 import com.yapp.fmz.domain.dto.ZoneDto;
@@ -13,13 +12,9 @@ import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import javax.persistence.OptimisticLockException;
-import javax.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 

--- a/src/main/java/com/yapp/fmz/domain/Zone.java
+++ b/src/main/java/com/yapp/fmz/domain/Zone.java
@@ -5,7 +5,6 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/yapp/fmz/domain/dto/ZoneDto.java
+++ b/src/main/java/com/yapp/fmz/domain/dto/ZoneDto.java
@@ -4,7 +4,6 @@ import com.yapp.fmz.domain.Address;
 import com.yapp.fmz.domain.Location;
 import com.yapp.fmz.domain.Zone;
 import lombok.Data;
-import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
 import java.util.ArrayList;

--- a/src/main/java/com/yapp/fmz/repository/RoomRepository.java
+++ b/src/main/java/com/yapp/fmz/repository/RoomRepository.java
@@ -1,7 +1,6 @@
 package com.yapp.fmz.repository;
 
 import com.yapp.fmz.domain.Room;
-import com.yapp.fmz.domain.Zone;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/yapp/fmz/repository/TransitRepository.java
+++ b/src/main/java/com/yapp/fmz/repository/TransitRepository.java
@@ -2,12 +2,9 @@ package com.yapp.fmz.repository;
 
 import com.yapp.fmz.domain.Location;
 import com.yapp.fmz.domain.Room;
-import com.yapp.fmz.domain.Zone;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface TransitRepository extends JpaRepository<Room, Long> {

--- a/src/main/java/com/yapp/fmz/repository/ZoneRepository.java
+++ b/src/main/java/com/yapp/fmz/repository/ZoneRepository.java
@@ -4,10 +4,8 @@ import com.yapp.fmz.domain.Zone;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
 
-import javax.persistence.QueryHint;
 import java.util.List;
 
 @Repository

--- a/src/main/java/com/yapp/fmz/repository/ZoneRepositoryCustom.java
+++ b/src/main/java/com/yapp/fmz/repository/ZoneRepositoryCustom.java
@@ -1,9 +1,5 @@
 package com.yapp.fmz.repository;
 
-import com.yapp.fmz.domain.Zone;
-
-import java.util.List;
-
 public interface ZoneRepositoryCustom {
 
 }

--- a/src/main/java/com/yapp/fmz/repository/ZoneRepositoryCustomImpl.java
+++ b/src/main/java/com/yapp/fmz/repository/ZoneRepositoryCustomImpl.java
@@ -1,15 +1,5 @@
 package com.yapp.fmz.repository;
 
-import com.yapp.fmz.domain.Room;
-import com.yapp.fmz.domain.Zone;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-
 public class ZoneRepositoryCustomImpl implements ZoneRepositoryCustom {
 
 }

--- a/src/main/java/com/yapp/fmz/service/ZoneService.java
+++ b/src/main/java/com/yapp/fmz/service/ZoneService.java
@@ -1,7 +1,6 @@
 package com.yapp.fmz.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yapp.fmz.domain.Location;
 import com.yapp.fmz.domain.Room;
 import com.yapp.fmz.domain.Zone;
 import com.yapp.fmz.domain.enu.Category;
@@ -13,16 +12,11 @@ import com.yapp.fmz.repository.ZoneRepository;
 import com.yapp.fmz.utils.GoogleApi;
 import com.yapp.fmz.utils.KakaoApi;
 import com.yapp.fmz.utils.ProjectionUtils;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.junit.Test;
 import org.osgeo.proj4j.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Service
-public class ZoneService {
+public class ZoneService implements CommandLineRunner {
     @Autowired
     ZoneRepository zoneRepository;
     @Autowired
@@ -304,7 +298,6 @@ public class ZoneService {
         return testZonesHasRoom;
     }
 
-    @PostConstruct
     public List<Zone> findOnlyRecommendZones(String address) {
 //         주소->좌표 변환
         HashMap<String, String> location = kakaoAPI.convertAddressToLocation(address);
@@ -393,5 +386,11 @@ public class ZoneService {
         }
         return ret;
 
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        String address = "서울특별시 강남구 역삼동 테헤란로48길 10";
+        findOnlyRecommendZones(address);
     }
 }

--- a/src/main/java/com/yapp/fmz/utils/GoogleApi.java
+++ b/src/main/java/com/yapp/fmz/utils/GoogleApi.java
@@ -1,7 +1,6 @@
 package com.yapp.fmz.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yapp.fmz.domain.Zone;
 import com.yapp.fmz.domain.vo.LocationVo;
 import org.json.simple.JSONArray;
@@ -17,11 +16,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/com/yapp/fmz/utils/KakaoApi.java
+++ b/src/main/java/com/yapp/fmz/utils/KakaoApi.java
@@ -8,11 +8,8 @@ import com.yapp.fmz.domain.vo.PlaceVo;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.*;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -21,7 +18,6 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class KakaoApi {

--- a/src/main/java/com/yapp/fmz/utils/PeterApi.java
+++ b/src/main/java/com/yapp/fmz/utils/PeterApi.java
@@ -1,17 +1,8 @@
 package com.yapp.fmz.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yapp.fmz.domain.Room;
-import com.yapp.fmz.domain.Zone;
-import com.yapp.fmz.domain.vo.LocationVo;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -21,11 +12,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @Component

--- a/src/test/java/com/yapp/fmz/controller/ZoneControllerTest.java
+++ b/src/test/java/com/yapp/fmz/controller/ZoneControllerTest.java
@@ -1,19 +1,8 @@
 package com.yapp.fmz.controller;
 
-import com.yapp.fmz.domain.Zone;
-import com.yapp.fmz.domain.dto.ZoneDto;
 import com.yapp.fmz.service.ZoneService;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.web.bind.annotation.GetMapping;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.Assert.*;
 
 @SpringBootTest
 class ZoneControllerTest {


### PR DESCRIPTION
* 스프링 초기 로딩 시에 한 번 (매물이 있는 기초구역 관련 쿼리)를 한 번 호출하여 이후에 캐싱이 적용되도록 함
* 기존에 고려하던 PostConstruct는 호출 시 사용하는 repository가 bean으로 등록되지 않은 시점이라 폐기
* ZoneService에 CommandLineRunner을 상속하여 override한 run 함수안에서 호출하는 방식으로 변경